### PR TITLE
Change policy to look for negative condition

### DIFF
--- a/policies/ubuntu24_aum_vms/policy.json
+++ b/policies/ubuntu24_aum_vms/policy.json
@@ -119,6 +119,10 @@
               {
                 "equals": "AutomaticByPlatform",
                 "field": "Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration.patchSettings.assessmentMode"
+              },
+              {
+                "field": "Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration.patchSettings.patchMode",
+                "notEquals": "AutomaticByPlatform"
               }
             ]
           },

--- a/policies/ubuntu24_aum_vmss/policy.json
+++ b/policies/ubuntu24_aum_vmss/policy.json
@@ -133,6 +133,10 @@
               {
                 "equals": "AutomaticByPlatform",
                 "field": "Microsoft.Compute/virtualMachineScaleSets/virtualMachineProfile.osProfile.linuxConfiguration.patchSettings.assessmentMode"
+              },
+              {
+                "field": "Microsoft.Compute/virtualMachineScaleSets/virtualMachineProfile.osProfile.linuxConfiguration.patchSettings.patchMode",
+                "notEquals": "AutomaticByPlatform"
               }
             ]
           },


### PR DESCRIPTION
### Jira link

See [DTSPO-29368](https://tools.hmcts.net/jira/browse/DTSPO-29368)

### Change description

Azure wasn’t reading the status correct for new VMs and was only seeing AUM status, after it had been, manually set. This now tests for the negative condition and correctly sees new machines, with inherited settings.

### Testing done

Tested via CLI.

### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
