### PR TITLE
Adding Copy tag policy to copy tags

### DIFF
--- a/assignments/nonlive/subscriptions/e6b5053b-4c38-4475-a835-a025aeb3d8c7/assign.copy.rg.required.tags.json
+++ b/assignments/nonlive/subscriptions/e6b5053b-4c38-4475-a835-a025aeb3d8c7/assign.copy.rg.required.tags.json
@@ -1,0 +1,31 @@
+{
+  "id": "/subscriptions/e6b5053b-4c38-4475-a835-a025aeb3d8c7/providers/Microsoft.Authorization/policyAssignments/CppCopyResourceGroupTags",
+  "name": "CppCopyResourceGroupTags",
+  "properties": {
+    "description": "Appends required tags and values from the resource group to resources that are missing them",
+    "displayName": "CPP Copy required tags from resource group (nonlive)",
+    "enforcementMode": "Default",
+    "metadata": {
+      "assignedBy": "github.com/hmcts/cpp-azure-policy"
+    },
+    "nonComplianceMessages": [
+      {
+        "message": "Resource is missing required tags copied from the resource group. See https://github.com/hmcts/cpp-azure-policy/blob/master/policies/copy-rg-required-tags/README.md"
+      }
+    ],
+    "notScopes": [],
+    "parameters": {
+      "tagNames": {
+        "value": [
+          "environment",
+          "application",
+          "businessArea",
+          "builtFrom"
+        ]
+      }
+    },
+    "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/e2995d11-9947-4e78-9de6-d44e0603518e/providers/Microsoft.Authorization/policyDefinitions/CppCopyResourceGroupTags",
+    "scope": "/subscriptions/e6b5053b-4c38-4475-a835-a025aeb3d8c7"
+  },
+  "type": "Microsoft.Authorization/policyAssignments"
+}


### PR DESCRIPTION
Copy tags policy allows copying default mandatory tags from the RG to the resoruce where we can not able to add the tags.

  "environment",
          "application",
          "businessArea",
          "builtFrom"


this policy is already in use here -  https://github.com/hmcts/azure-policy/blob/master/policies/copy-rg-required-tags/README.md 